### PR TITLE
Add support for concurrently walking

### DIFF
--- a/compile.go
+++ b/compile.go
@@ -1,0 +1,258 @@
+package type_walk
+
+import (
+	"fmt"
+	g_reflect "github.com/goccy/go-reflect"
+	sync_map "github.com/zolstein/sync-map"
+	"reflect"
+	"sync"
+	"unsafe"
+)
+
+type simpleCompiler[Ctx any] struct {
+	typeFns    map[g_reflect.Type]*walkFn[Ctx]
+	compileFns [NUM_KIND]unsafe.Pointer
+}
+
+func newSimpleCompiler[Ctx any](register *Register[Ctx]) *simpleCompiler[Ctx] {
+	typeFns := make(map[g_reflect.Type]*walkFn[Ctx], len(register.typeFns))
+	for i := range register.typeFns {
+		e := register.typeFns[i]
+		typeFns[e.t] = &e.fn
+	}
+	return &simpleCompiler[Ctx]{
+		typeFns:    typeFns,
+		compileFns: register.compileFns,
+	}
+}
+
+func (c *simpleCompiler[Ctx]) getFn(t g_reflect.Type) (fn *walkFn[Ctx], err error) {
+	fn, ok := c.typeFns[t]
+	if !ok {
+		if t == nil {
+			// This panics, rather than returning an error, because it's an easily preventable user error.
+			// Check for nil before calling Walk!
+			// Maybe we should have a way to specify a handler for a nil interface?
+			panic("cannot compile function for nil type")
+		}
+		fn = new(walkFn[Ctx])
+		c.typeFns[t] = fn
+		*fn, err = c.compileFn(t)
+	}
+	return fn, err
+}
+
+func (c *simpleCompiler[Ctx]) compileFn(t g_reflect.Type) (walkFn[Ctx], error) {
+	k := t.Kind()
+	fnPtr := c.compileFns[k]
+	if fnPtr == nil {
+		return nil, fmt.Errorf("no registered handler for type kind %v", k)
+	}
+	switch k {
+	case g_reflect.Array:
+		return c.compileArray(t, castTo[CompileArrayFn[Ctx]](fnPtr))
+	case g_reflect.Ptr:
+		return c.compilePtr(t, castTo[CompilePtrFn[Ctx]](fnPtr))
+	case g_reflect.Slice:
+		return c.compileSlice(t, castTo[CompileSliceFn[Ctx]](fnPtr))
+	case g_reflect.Struct:
+		return c.compileStruct(t, castTo[CompileStructFn[Ctx]](fnPtr))
+	case g_reflect.Map:
+		return c.compileMap(t, castTo[CompileMapFn[Ctx]](fnPtr))
+	case g_reflect.Interface:
+		return c.compileInterface(t, castTo[CompileInterfaceFn[Ctx]](fnPtr))
+	default:
+		compileFn := castTo[compileFn[Ctx]](fnPtr)
+		return compileFn(g_reflect.ToReflectType(t)), nil
+	}
+}
+
+func (c *simpleCompiler[Ctx]) compileArray(t g_reflect.Type, fn CompileArrayFn[Ctx]) (walkFn[Ctx], error) {
+	arrayWalkFn := fn(g_reflect.ToReflectType(t))
+	elemFn, err := c.getFn(t.Elem())
+	if err != nil {
+		return nil, err
+	}
+	arrayMeta := arrayMetadata[Ctx]{
+		typ:      t,
+		elemSize: t.Elem().Size(),
+		length:   t.Len(),
+		elemFn:   elemFn,
+	}
+	return func(ctx Ctx, arg arg) error {
+		structWalker := Array[Ctx]{meta: &arrayMeta, arg: arg}
+		return arrayWalkFn(ctx, structWalker)
+	}, nil
+}
+
+func (c *simpleCompiler[Ctx]) compilePtr(t g_reflect.Type, fn CompilePtrFn[Ctx]) (walkFn[Ctx], error) {
+	ptrWalkFn := fn(g_reflect.ToReflectType(t))
+	elemFn, err := c.getFn(t.Elem())
+	if err != nil {
+		return nil, err
+	}
+	ptrMeta := ptrMetadata[Ctx]{
+		typ:    t,
+		elemFn: elemFn,
+	}
+	return func(ctx Ctx, arg arg) error {
+		structWalker := Ptr[Ctx]{meta: &ptrMeta, arg: arg}
+		return ptrWalkFn(ctx, structWalker)
+	}, nil
+}
+
+func (c *simpleCompiler[Ctx]) compileSlice(t g_reflect.Type, fn CompileSliceFn[Ctx]) (walkFn[Ctx], error) {
+	sliceWalkFn := fn(g_reflect.ToReflectType(t))
+	elemFn, err := c.getFn(t.Elem())
+	if err != nil {
+		return nil, err
+	}
+	sliceMeta := sliceMetadata[Ctx]{
+		typ:      t,
+		elemSize: t.Elem().Size(),
+		elemFn:   elemFn,
+	}
+	return func(ctx Ctx, arg arg) error {
+		structWalker := Slice[Ctx]{meta: &sliceMeta, arg: arg}
+		return sliceWalkFn(ctx, structWalker)
+	}, nil
+}
+
+func (c *simpleCompiler[Ctx]) compileStruct(t g_reflect.Type, fn CompileStructFn[Ctx]) (walkFn[Ctx], error) {
+	reg := structFieldRegister{
+		typ: t,
+	}
+	structWalkFn := fn(g_reflect.ToReflectType(t), StructFieldRegister{&reg})
+	meta := &structMetadata[Ctx]{
+		typ:       t,
+		fieldInfo: make([]structFieldMetadata[Ctx], len(reg.indexes)),
+	}
+	for i, idx := range reg.indexes {
+		ft := t
+		offsets := []uintptr{0}
+		for i, x := range idx {
+			if i > 0 && ft.Kind() == reflect.Ptr && ft.Elem().Kind() == reflect.Struct {
+				ft = ft.Elem()
+				offsets = append(offsets, 0)
+			}
+			f := ft.Field(x)
+			ft = f.Type
+			offsets[len(offsets)-1] += f.Offset
+		}
+
+		fn, err := c.getFn(ft)
+		if err != nil {
+			return nil, err
+		}
+		meta.fieldInfo[i] = structFieldMetadata[Ctx]{
+			typ:    ft,
+			lookup: lookupFieldFn(offsets),
+			fn:     fn,
+		}
+	}
+	return func(ctx Ctx, arg arg) error {
+		structWalker := Struct[Ctx]{meta: meta, arg: arg}
+		return structWalkFn(ctx, structWalker)
+	}, nil
+}
+
+type lookupFn func(arg) arg
+
+func lookupFieldFn(offsets []uintptr) lookupFn {
+	return func(a arg) arg {
+		for i, offset := range offsets {
+			if i >= 1 {
+				// If len(offsets) >= 1, the lookup goes through at least one pointer. In this case, it's necessarily
+				// behind a pointer, and therefore addressable.
+				a.canAddr = true
+				a.p = *(*unsafe.Pointer)(a.p)
+				if a.p == nil {
+					return arg{}
+				}
+			}
+			a.p = unsafe.Add(a.p, offset)
+		}
+		return a
+	}
+}
+
+func (c *simpleCompiler[Ctx]) compileMap(t g_reflect.Type, fn CompileMapFn[Ctx]) (walkFn[Ctx], error) {
+	mapWalkFn := fn(g_reflect.ToReflectType(t))
+	keyFn, err := c.getFn(t.Key())
+	if err != nil {
+		return nil, err
+	}
+	valFn, err := c.getFn(t.Elem())
+	if err != nil {
+		return nil, err
+	}
+	mapMeta := mapMetadata[Ctx]{
+		typ:   t,
+		keyFn: keyFn,
+		valFn: valFn,
+	}
+	return func(ctx Ctx, arg arg) error {
+		mapWalker := Map[Ctx]{meta: &mapMeta, arg: arg}
+		return mapWalkFn(ctx, mapWalker)
+	}, nil
+}
+
+func (c *simpleCompiler[Ctx]) compileInterface(t g_reflect.Type, fn CompileInterfaceFn[Ctx]) (walkFn[Ctx], error) {
+	ifaceWalkFn := fn(g_reflect.ToReflectType(t))
+	ifaceMeta := ifaceMetadata[Ctx]{
+		typ:   t,
+		fnSrc: c.getFn,
+	}
+	return func(ctx Ctx, arg arg) error {
+		structWalker := Interface[Ctx]{meta: &ifaceMeta, arg: arg}
+		return ifaceWalkFn(ctx, structWalker)
+	}, nil
+}
+
+type threadSafeCompiler[Ctx any] struct {
+	typeFns sync_map.Map[g_reflect.Type, *walkFn[Ctx]]
+	inner   simpleCompiler[Ctx]
+	m       sync.Mutex
+}
+
+func newThreadSafeCompiler[Ctx any](register *Register[Ctx]) *threadSafeCompiler[Ctx] {
+	c := &threadSafeCompiler[Ctx]{
+		inner:   *newSimpleCompiler[Ctx](register),
+		typeFns: sync_map.Map[g_reflect.Type, *walkFn[Ctx]]{},
+	}
+	for t, fn := range c.inner.typeFns {
+		c.typeFns.Store(t, fn)
+	}
+	return c
+}
+
+func (c *threadSafeCompiler[Ctx]) getFn(t g_reflect.Type) (fn *walkFn[Ctx], err error) {
+	// Check typeFns first before grabbing the lock. If it's here, we know it's non-nil, since it only exists in the
+	// inner map until we actually return from this function. (There's no parallel vs recursive case.)
+	fn, ok := c.typeFns.Load(t)
+	if !ok {
+		if t == nil {
+			// This panics, rather than returning an error, because it's an easily preventable user error.
+			// Check for nil before calling Walk!
+			// Maybe we should have a way to specify a handler for a nil interface?
+			panic("cannot compile function for nil type")
+		}
+
+		c.m.Lock()
+		defer c.m.Unlock()
+
+		// Check again. If another thread tried to get the same type concurrently, it may have already added it.
+		fn, ok = c.typeFns.Load(t)
+		if !ok {
+			// It's safe to call inner.getFn while holding the lock because no other threads will attempt to read or
+			// update its typeFns map concurrently.
+			// N.b. It might be slightly better to copy the full simpleCompiler.getFn implementation, make it work
+			// directly on typeFns, and explicitly check for nil values while not holding the lock.
+			fn, err = c.inner.getFn(t)
+			if err != nil {
+				c.typeFns.Store(t, fn)
+			}
+		}
+	}
+	return fn, err
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/goccy/go-reflect v1.2.0
 	github.com/stretchr/testify v1.9.0
+	github.com/zolstein/sync-map v0.0.0-20241114025029-d8a8d5a801cb
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/zolstein/sync-map v0.0.0-20241114025029-d8a8d5a801cb h1:bj398bzUIKeNSo1BsBhWuqW4AUMx8dTHLGzLPJPnxHI=
+github.com/zolstein/sync-map v0.0.0-20241114025029-d8a8d5a801cb/go.mod h1:4gHvvAObHgJDhP4/b9a6jpyxmbRMuogXZX8sVG88lPg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/walk_concurrent_test.go
+++ b/walk_concurrent_test.go
@@ -1,0 +1,118 @@
+package type_walk_test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	tw "github.com/zolstein/type-walk"
+)
+
+func TestConcurrent(t *testing.T) {
+	r := tw.NewRegister[struct{}]()
+	var global atomic.Int64
+	r.RegisterCompileInt64Fn(func(r reflect.Type) tw.WalkFn[struct{}, int64] {
+		return func(s struct{}, a tw.Arg[int64]) error {
+			global.Add(a.Get())
+			return nil
+		}
+	})
+
+	type A int64
+	type B int64
+	type fn func(walker *tw.Walker[struct{}], i int64)
+
+	var start sync.WaitGroup
+	var end sync.WaitGroup
+
+	walkA := func(walker *tw.Walker[struct{}], i int64) {
+		start.Wait()
+		err := walker.Walk(struct{}{}, A(i))
+		require.NoError(t, err)
+		end.Done()
+	}
+
+	walkB := func(walker *tw.Walker[struct{}], i int64) {
+		start.Wait()
+		err := walker.Walk(struct{}{}, B(i))
+		require.NoError(t, err)
+		end.Done()
+	}
+
+	typeForA := func(walker *tw.Walker[struct{}], i int64) {
+		start.Wait()
+		fn, err := tw.TypeFnFor[A](walker)
+		require.NoError(t, err)
+		a := A(i)
+		err = fn(struct{}{}, &a)
+		require.NoError(t, err)
+		end.Done()
+	}
+
+	typeForB := func(walker *tw.Walker[struct{}], i int64) {
+		start.Wait()
+		fn, err := tw.TypeFnFor[B](walker)
+		require.NoError(t, err)
+		b := B(i)
+		err = fn(struct{}{}, &b)
+		require.NoError(t, err)
+		end.Done()
+	}
+
+	helper := func(fns []fn) {
+		for i := 0; i < 10000; i++ {
+			global.Store(0)
+			walker := tw.NewWalker[struct{}](r, tw.WithThreadSafe)
+			start.Add(1)
+			end.Add(100)
+			for j := 0; j < 100; j++ {
+				go fns[j%len(fns)](walker, int64(j))
+			}
+			start.Done()
+			end.Wait()
+			assert.Equal(t, 4950, int(global.Load()))
+		}
+	}
+
+	type testCase struct {
+		name string
+		fns  []fn
+	}
+
+	cases := []testCase{
+		{
+			name: "walk-one-type",
+			fns:  []fn{walkA},
+		},
+		{
+			name: "walk-two-types",
+			fns:  []fn{walkA, walkB},
+		},
+		{
+			name: "type-for-one-type",
+			fns:  []fn{typeForA},
+		},
+		{
+			name: "type-for-two-types",
+			fns:  []fn{typeForA, typeForB},
+		},
+		{
+			name: "mix-one-type",
+			fns:  []fn{typeForA, walkA},
+		},
+		{
+			name: "mix-all",
+			fns:  []fn{walkA, walkB, typeForA, typeForB},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			helper(tc.fns)
+		})
+	}
+
+}

--- a/walk_concurrent_test.go
+++ b/walk_concurrent_test.go
@@ -63,7 +63,7 @@ func TestConcurrent(t *testing.T) {
 	}
 
 	helper := func(fns []fn) {
-		for i := 0; i < 10000; i++ {
+		for i := 0; i < 1000; i++ {
 			global.Store(0)
 			walker := tw.NewWalker[struct{}](r, tw.WithThreadSafe)
 			start.Add(1)


### PR DESCRIPTION
Add an option to create a thread-safe walker which uses a modified sync.Map to store walkFns. Compiling is still single-threaded behind a mutex because this simplifies handling of recursive structures - however the sync.Map avoids the need to always take a lock to look up a walkFn.